### PR TITLE
Part 10.3 / Fix variable name for comparison object in cheaper() example.

### DIFF
--- a/data/part-10/3-oo-programming-techniques.md
+++ b/data/part-10/3-oo-programming-techniques.md
@@ -59,11 +59,11 @@ class Product:
     def price(self):
         return self.__price
 
-    def cheaper(self, Product):
-        if self.__price < Product.price:
+    def cheaper(self, other: Product) -> Product:
+        if self.__price < other.price:
             return self
         else:
-            return Product
+            return other
 ```
 
 ```python


### PR DESCRIPTION
This renames the variable name for the comparison object and adds type hinting for the Person.cheaper() method in part 10.3.

Currently, the material uses a variable 'Person' as the comparison object for cheaper(), which is confusing.

Briefly discussed on [course Discord](https://discord.com/channels/757581218085863474/883270047219462154/1180238720696332358).